### PR TITLE
Move messageCount exception to getMessageCount() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- The exception thrown for message content which exceeds the maximum allowed
+number of concatenated SMS (255) has been moved from the inspection on construct
+to the `getMessageCount()` method. This allows the implementation to still read
+the other stats from the constructed object. (The constructor will still throw
+an exception if the message string contained characters that cannot be parsed).
 
 ## [1.0.0] - 2017-03-28
 Initial Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- New `validate()` method to check the content string matches the specification.
 ### Changed
 - Updated construct docblock to make it clear that the SMS message content
 should be provided as a UTF-8 string. In most cases this should not require any
@@ -12,7 +14,7 @@ implementation changes as UTF-8 is the
 [default charset for PHP](http://php.net/manual/en/ini.core.php#ini.default-charset).
 - The exception thrown for message content which exceeds the maximum allowed
 number of concatenated SMS (255) has been moved from the inspection on construct
-to the `getMessageCount()` method. This allows the implementation to still read
+to a dedicated `validate()` method. This allows the implementation to still read
 the other stats from the constructed object. (The constructor will still throw
 an exception if the message string contained characters that cannot be parsed).
 

--- a/src/SmsLength.php
+++ b/src/SmsLength.php
@@ -115,14 +115,9 @@ class SmsLength
      * Get number of messages that would be used to send the given content size
      *
      * @return int
-     * @throws InvalidArgumentException
      */
     public function getMessageCount()
     {
-        if ($this->messageCount > self::MAXIMUM_CONCATENATED_SMS) {
-            throw new InvalidArgumentException('Message size exceeds maximum');
-        }
-
         return $this->messageCount;
     }
 
@@ -145,6 +140,21 @@ class SmsLength
         }
 
         return $this->messageCount * $concat;
+    }
+
+    /**
+     * Check the message content is valid for an SMS
+     *
+     * @return bool
+     * @throws InvalidArgumentException
+     */
+    public function validate()
+    {
+        if ($this->messageCount > self::MAXIMUM_CONCATENATED_SMS) {
+            throw new InvalidArgumentException('Message count cannot exceed ' . self::MAXIMUM_CONCATENATED_SMS);
+        }
+
+        return true;
     }
 
     /**

--- a/src/SmsLength.php
+++ b/src/SmsLength.php
@@ -115,9 +115,14 @@ class SmsLength
      * Get number of messages that would be used to send the given content size
      *
      * @return int
+     * @throws InvalidArgumentException
      */
     public function getMessageCount()
     {
+        if ($this->messageCount > self::MAXIMUM_CONCATENATED_SMS) {
+            throw new InvalidArgumentException('Message size exceeds maximum');
+        }
+
         return $this->messageCount;
     }
 
@@ -195,10 +200,6 @@ class SmsLength
         $this->messageCount = 1;
         if ($this->size > $singleSize) {
             $this->messageCount = (int)ceil($this->size / $concatSize);
-        }
-
-        if ($this->messageCount > self::MAXIMUM_CONCATENATED_SMS) {
-            throw new InvalidArgumentException('Message size exceeds maximum');
         }
     }
 }

--- a/tests/SmsLengthTest.php
+++ b/tests/SmsLengthTest.php
@@ -97,7 +97,7 @@ class SmsLengthTest extends \PHPUnit_Framework_TestCase
      * @param int $upperBreak
      * @medium Expect tests to take >1 but <10
      * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Message size exceeds maximum
+     * @expectedExceptionMessage Message count cannot exceed 255
      */
     public function testTooLarge($content, $encoding, $characters, $messageCount, $upperBreak)
     {

--- a/tests/SmsLengthTest.php
+++ b/tests/SmsLengthTest.php
@@ -52,6 +52,8 @@ class SmsLengthTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($characters, $size->getSize());
         $this->assertSame($messageCount, $size->getMessageCount());
         $this->assertSame($upperBreak, $size->getUpperBreakpoint());
+
+        $this->assertTrue($size->validate());
     }
 
     public function providerSize()
@@ -91,19 +93,23 @@ class SmsLengthTest extends \PHPUnit_Framework_TestCase
      * @param string $content
      * @param string $encoding
      * @param int $characters
+     * @param int $messageCount
+     * @param int $upperBreak
      * @medium Expect tests to take >1 but <10
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage Message size exceeds maximum
      */
-    public function testTooLarge($content, $encoding, $characters)
+    public function testTooLarge($content, $encoding, $characters, $messageCount, $upperBreak)
     {
         $size = new SmsLength($content);
 
         $this->assertSame($encoding, $size->getEncoding());
         $this->assertSame($characters, $size->getSize());
+        $this->assertSame($messageCount, $size->getMessageCount());
+        $this->assertSame($upperBreak, $size->getUpperBreakpoint());
 
         // Trigger exception
-        $size->getMessageCount();
+        $size->validate();
     }
 
     public function providerTooLarge()
@@ -112,15 +118,15 @@ class SmsLengthTest extends \PHPUnit_Framework_TestCase
         // ucs-2 max is 17085 (255 * 67)
         return [
             // long 7-bit, 10 * 3902 = 39020
-            [str_repeat('simple msg', 3902), '7-bit', 39020],
+            [str_repeat('simple msg', 3902), '7-bit', 39020, 256, 39168],
 
             // long 7-bit extended, 18 * 2168 = 39024
-            [str_repeat(self::GSM0338_EXTENDED, 2168), '7-bit', 39024],
+            [str_repeat(self::GSM0338_EXTENDED, 2168), '7-bit', 39024, 256, 39168],
 
             // long UCS-2 single, 17 * 1006 = 17102
             // long UCS-2 double, 18 * 950 = 17100
-            [str_repeat("simple msg plus •", 1006), 'ucs-2', 17102],
-            [str_repeat("simple msg plus \xf0\x9f\x93\xb1", 950), 'ucs-2', 17100]
+            [str_repeat("simple msg plus •", 1006), 'ucs-2', 17102, 256, 17152],
+            [str_repeat("simple msg plus \xf0\x9f\x93\xb1", 950), 'ucs-2', 17100, 256, 17152]
         ];
     }
 }

--- a/tests/SmsLengthTest.php
+++ b/tests/SmsLengthTest.php
@@ -89,30 +89,38 @@ class SmsLengthTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider providerTooLarge
      * @param string $content
+     * @param string $encoding
+     * @param int $characters
      * @medium Expect tests to take >1 but <10
      * @expectedException InvalidArgumentException
      * @expectedExceptionMessage Message size exceeds maximum
      */
-    public function testTooLarge($content)
+    public function testTooLarge($content, $encoding, $characters)
     {
-        new SmsLength($content);
+        $size = new SmsLength($content);
+
+        $this->assertSame($encoding, $size->getEncoding());
+        $this->assertSame($characters, $size->getSize());
+
+        // Trigger exception
+        $size->getMessageCount();
     }
 
     public function providerTooLarge()
     {
-        // 7-bit max is 39,015 (255 * 153)
-        // ucs-2 max is 17,085 (255 * 67)
+        // 7-bit max is 39015 (255 * 153)
+        // ucs-2 max is 17085 (255 * 67)
         return [
             // long 7-bit, 10 * 3902 = 39020
-            [str_repeat('simple msg', 3902)],
+            [str_repeat('simple msg', 3902), '7-bit', 39020],
 
             // long 7-bit extended, 18 * 2168 = 39024
-            [str_repeat(self::GSM0338_EXTENDED, 2168)],
+            [str_repeat(self::GSM0338_EXTENDED, 2168), '7-bit', 39024],
 
-            // long UCS-2 single, 17 * 1006 = 17,102
-            // long UCS-2 double, 18 * 950 = 17,100
-            [str_repeat("simple msg plus •", 1006)],
-            [str_repeat("simple msg plus \xf0\x9f\x93\xb1", 950)]
+            // long UCS-2 single, 17 * 1006 = 17102
+            // long UCS-2 double, 18 * 950 = 17100
+            [str_repeat("simple msg plus •", 1006), 'ucs-2', 17102],
+            [str_repeat("simple msg plus \xf0\x9f\x93\xb1", 950), 'ucs-2', 17100]
         ];
     }
 }


### PR DESCRIPTION
Allows the constructor to complete, and the other properties be read