### PR TITLE
Process message content as UTF-8 string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Updated construct docblock to make it clear that the SMS message content
+should be provided as a UTF-8 string. In most cases this should not require any
+implementation changes as UTF-8 is the
+[default charset for PHP](http://php.net/manual/en/ini.core.php#ini.default-charset).
 
 ## [1.0.0] - 2017-03-28
 Initial Release

--- a/src/SmsLength.php
+++ b/src/SmsLength.php
@@ -83,7 +83,7 @@ class SmsLength
     /**
      * Constructor
      *
-     * @param string $messageContent
+     * @param string $messageContent SMS message content (UTF-8)
      * @throws InvalidArgumentException
      */
     public function __construct($messageContent)
@@ -160,9 +160,9 @@ class SmsLength
         // Any character outside the 7-bit alphabet switches the entire encoding to UCS-2
         $this->encoding = '7-bit';
         $this->size = 0;
-        $mbLength = mb_strlen($messageContent);
+        $mbLength = mb_strlen($messageContent, 'UTF-8');
         for ($i = 0; $i < $mbLength; $i++) {
-            $char = mb_substr($messageContent, $i, 1);
+            $char = mb_substr($messageContent, $i, 1, 'UTF-8');
             if (in_array($char, self::GSM0338_BASIC)) {
                 $this->size++;
             } elseif (in_array($char, self::GSM0338_EXTENDED)) {
@@ -178,8 +178,8 @@ class SmsLength
             // Those with two UTF-16 code points consume two characters in the SMS
             $this->size = 0;
             for ($i = 0; $i < $mbLength; $i++) {
-                $char = mb_substr($messageContent, $i, 1);
-                $utf16Hex = bin2hex(mb_convert_encoding($char, 'UTF-16'));
+                $char = mb_substr($messageContent, $i, 1, 'UTF-8');
+                $utf16Hex = bin2hex(mb_convert_encoding($char, 'UTF-16', 'UTF-8'));
                 $this->size += strlen($utf16Hex) / 4;
             }
         }


### PR DESCRIPTION
Set all mb_* functions to expect UTF-8, rather than rely on mb_internal_encoding.
Update docblock to make this clear